### PR TITLE
Fix stack overflow on windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -50,7 +50,7 @@ pub fn run() {
         )
         .unwrap();
     const PIX_SIZE: usize = CAM_WIDTH as usize * CAM_HEIGHT as usize * 3;
-    let mut pixels: [u8; PIX_SIZE] = [0; PIX_SIZE];
+    let mut pixels: Vec<u8> = vec![0; PIX_SIZE];
 
     let red = Material {
         ambient: Vec3f::new(0.1, 0.1, 0.1),


### PR DESCRIPTION
Dunno what exaclty the stack size is, but it seems that it wasn't big
enough for 640x480 pixels. So switch it to Vec, which is heap-allocated
and it fixed the issue